### PR TITLE
 Replace the youtube API with web scrapping

### DIFF
--- a/server/modules/youtube_videos.py
+++ b/server/modules/youtube_videos.py
@@ -1,4 +1,8 @@
-import webbrowser, requests, sys, bs4, re
+import webbrowser
+import requests
+import sys
+import bs4
+import re
 
 class youtube_results:
   def youtube_search(self, q):
@@ -38,7 +42,3 @@ class youtube_results:
         else:
             rel_videos.append([videoLinks2[i].get('title'),VideosId2.group('id')])
     return rel_videos
-
-
-
-  

--- a/server/modules/youtube_videos.py
+++ b/server/modules/youtube_videos.py
@@ -1,75 +1,44 @@
-# API , video_id documentation : https://gist.github.com/dgp/1b24bf2961521bd75d6c
-
-from apiclient.discovery import build
-from apiclient.errors import HttpError
-
-
-DEVELOPER_KEY = "PASTE_YOUR_API_KEY_HERE"
-YOUTUBE_API_SERVICE_NAME = "youtube"
-YOUTUBE_API_VERSION = "v3"
+import webbrowser, requests, sys, bs4, re
 
 class youtube_results:
-  def youtube_search(self, q, max_results=50,order="relevance", token=None, location=None, location_radius=None, videoCategoryId="10"):
+  def youtube_search(self, q):
+    
+    res = requests.get("https://www.youtube.com/results?search_query=" + q)
+    res.raise_for_status()
 
-    youtube = build(YOUTUBE_API_SERVICE_NAME, YOUTUBE_API_VERSION,
-    developerKey=DEVELOPER_KEY)
+    searchSoup = bs4.BeautifulSoup(res.content,features="html.parser")
+    videoLinks = searchSoup.select('a.yt-uix-tile-link.yt-ui-ellipsis.yt-ui-ellipsis-2.yt-uix-sessionlink.spf-link')
 
-    search_response = youtube.search().list(
-      q=q,
-      type="video",
-      pageToken=token,
-      order = order,
-      part="id,snippet",
-      maxResults=max_results,
-      location=location,
-      locationRadius=location_radius
-
-    ).execute()
-
+    max_results = min(20,len(videoLinks))
     videos = []
+    for i in range(max_results):    
+        regex = re.compile(r'/(watch\?v=|embed/|v/|.+\?v=)?(?P<id>[A-Za-z0-9\-=_]{11})')
+        VideosId = regex.match(videoLinks[i].get('href'))
+        if not VideosId:
+            print('no match')
+        else:
+            videos.append([videoLinks[i].get('title'),VideosId.group('id')])
+    return videos
 
-    for search_result in search_response.get("items", []):
-      if search_result["id"]["kind"] == "youtube#video":
-        videos.append(search_result)
+  def youtube_related(self, relatedto_videoid):
+    related = requests.get("https://www.youtube.com/watch?v=" + relatedto_videoid)
+    related.raise_for_status()
 
-    try:
-      nexttok = search_response["nextPageToken"]
-      return(nexttok, videos)
+    searchSoup2 = bs4.BeautifulSoup(related.content,features="html.parser")
+    videoLinks2 = searchSoup2.select('a.content-link.spf-link.yt-uix-sessionlink.spf-link')
+
+    max_results2 = min(20,len(videoLinks2))
+    rel_videos = []
+    
+    for i in range(max_results2):    
+        regex2 = re.compile(r'/(watch\?v=|embed/|v/|.+\?v=)?(?P<id>[A-Za-z0-9\-=_]{11})')
+        VideosId2 = regex2.match(videoLinks2[i].get('href'))
+        if not VideosId2:
+            print('no match')
+        else:
+            rel_videos.append([videoLinks2[i].get('title'),VideosId2.group('id')])
+    return rel_videos
+
+
+
   
-    except Exception as e:
-      nexttok = "last_page"
-      return(nexttok, videos)
-
-
-  def youtube_related(self, relatedto_videoid, max_results=20,order="relevance", token=None, location=None, location_radius=None, videoCategoryId="10"):
-
-    youtube = build(YOUTUBE_API_SERVICE_NAME, YOUTUBE_API_VERSION,
-      developerKey=DEVELOPER_KEY)
-
-    search_response = youtube.search().list(
-      relatedToVideoId = relatedto_videoid,
-      type="video",
-      pageToken=token,
-      order = order,
-      part="id,snippet",
-      maxResults=max_results,
-      location=location,
-      locationRadius=location_radius
-
-    ).execute()
-
-
-    videos = []
-
-    for search_result in search_response.get("items", []):
-      if search_result["id"]["kind"] == "youtube#video":
-        videos.append(search_result)
-
-    try:
-      nexttok = search_response["nextPageToken"]
-      return(nexttok, videos)
-
-    except Exception as e:
-      nexttok = "last_page"
-      return(nexttok, videos)
-

--- a/server/server.py
+++ b/server/server.py
@@ -21,7 +21,7 @@ class search_play_recommend:
     def search(self, search_query):
         search = youtube.youtube_search(search_query)
         art = coverpy.art(search_query)
-        result = dict([('title', search[1][0]['snippet']['title']), ('id', search[1][0]['id']['videoId']), ('album art', art)])
+        result = dict([('title', search[0][0]), ('id', search[0][1]), ('album art', art)])
         return(result)
 
     def play(self, video_id):
@@ -38,8 +38,8 @@ class search_play_recommend:
     def recommend(self, video_id):
         related_result = youtube.youtube_related(video_id)
         items = []
-        for video in related_result[1]:
-            items.append(dict([('title', video['snippet']['title']), ('id', video['id']['videoId'])]))
+        for video in related_result:
+            items.append(dict([('title', video[0]), ('id', video[1])]))
         return items
 
 song = search_play_recommend()


### PR DESCRIPTION
Fixes #21 
Used web scrapping as replacement of API.

## Description
youtube_search(): It searches the query on youtube and returns the links of all the results.
youtube_related(): It opens the first link returned by youtube_search() and returns the links of all the videos present in the related videos section.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Issue: #21 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
